### PR TITLE
Replay newer events in RM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Interactive wireframes generated from Adobe Experience Design (beta) https://xd.
 ## To Do
 * Optimistic locking on event creation
 * When an event is used to update the read model, it should compare version numbers to ensure consistency.
+* Implement Computer View
+* Implement DamageModel
+* Implement ComputerUserModel
+* Implement Teacher controller and views

--- a/src/LabLog.Domain/Entities/School.cs
+++ b/src/LabLog.Domain/Entities/School.cs
@@ -87,7 +87,8 @@ namespace LabLog.Domain.Entities
             if (ex.HasExceptions()) {throw ex;}
 
             var @event = LabEvent.Create(
-                Guid.NewGuid(),
+                //Guid.NewGuid(),
+                Id,
                 ++Version,
                 new ComputerAddedEvent(roomId, computer.SerialNumber, computer.ComputerName, computer.Position));
                 ApplyComputerAddedEvent(@event);

--- a/src/LabLog.Tests/ReadTests/EntityTests/ComputerTests.cs
+++ b/src/LabLog.Tests/ReadTests/EntityTests/ComputerTests.cs
@@ -21,9 +21,11 @@ namespace LabLog.ReadTests.EntityTests
                     Assert.Equal("Test Computer", t.Context.School.Rooms.Find(f => (f.Id == new Guid("11111111-1111-1111-1111-111111111113"))).Computers[0].Name);
                     Assert.Equal("Serial", t.Context.School.Rooms.Find(f => (f.Id == new Guid("11111111-1111-1111-1111-111111111113"))).Computers[0].SerialNumber);
                     Assert.Equal(9, t.Context.School.Rooms.Find(f => (f.Id == new Guid("11111111-1111-1111-1111-111111111113"))).Computers[0].Position);
+
                 })
                 .ExecuteAsync();
         }
+
 
     }
 }

--- a/src/LabLog.Tests/ReadTests/Steps/Steps.cs
+++ b/src/LabLog.Tests/ReadTests/Steps/Steps.cs
@@ -72,7 +72,7 @@ namespace LabLog.ReadTests.Steps
 
         public static void ReplayEvents (this IWhen<ReadSchoolContext> when)
         {
-            when.Context.School.ReplaySchoolEvents(when.Context.RetrievedEvents);
+            when.Context.School.Update(when.Context.RetrievedEvents);
         }
 
     }

--- a/src/LabLog/Migrations/20171021073335_initialCreate.Designer.cs
+++ b/src/LabLog/Migrations/20171021073335_initialCreate.Designer.cs
@@ -11,7 +11,7 @@ using System;
 namespace LabLog.Migrations
 {
     [DbContext(typeof(EventModelContext))]
-    [Migration("20171020115729_initialCreate")]
+    [Migration("20171021073335_initialCreate")]
     partial class initialCreate
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -82,6 +82,8 @@ namespace LabLog.Migrations
 
                     b.Property<string>("Name")
                         .IsRequired();
+
+                    b.Property<int>("_latestVersion");
 
                     b.HasKey("Id");
 

--- a/src/LabLog/Migrations/20171021073335_initialCreate.cs
+++ b/src/LabLog/Migrations/20171021073335_initialCreate.cs
@@ -29,7 +29,8 @@ namespace LabLog.Migrations
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "BLOB", nullable: false),
-                    Name = table.Column<string>(type: "TEXT", nullable: false)
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    _latestVersion = table.Column<int>(type: "INTEGER", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/src/LabLog/Migrations/EventModelContextModelSnapshot.cs
+++ b/src/LabLog/Migrations/EventModelContextModelSnapshot.cs
@@ -82,6 +82,8 @@ namespace LabLog.Migrations
                     b.Property<string>("Name")
                         .IsRequired();
 
+                    b.Property<int>("_latestVersion");
+
                     b.HasKey("Id");
 
                     b.ToTable("Schools");

--- a/src/LabLog/Models/EventModelContext.cs
+++ b/src/LabLog/Models/EventModelContext.cs
@@ -12,6 +12,7 @@ namespace LabLog
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlite("Data Source=./LabLog.db");
+            optionsBuilder.EnableSensitiveDataLogging();
 
         }
 

--- a/src/LabLog/Services/SchoolEventHandler.cs
+++ b/src/LabLog/Services/SchoolEventHandler.cs
@@ -16,16 +16,17 @@ namespace LabLog.Services
             _db = db;
             _user = user;
         }
-        public Domain.Entities.School School (Guid schoolId)
+        public Domain.Entities.School School (SchoolModel schoolModel)
         {
+                Guid schoolId = schoolModel.Id;
                 List<LabEvent> eventList = _db.LabEvents.Where(o => (o.SchoolId == schoolId)).ToList();
                 Domain.Entities.School school = new Domain.Entities.School(eventList, e =>
                 {
                     e.EventAuthor = _user;
                     _db.Add(e);
 
-                    SchoolModel schoolModel = _db.Schools.Where(w => (w.Id == schoolId)).SingleOrDefault();
-                    schoolModel.ReplaySchoolEvent(e);
+                    schoolModel.Update(eventList);
+                    schoolModel.ReplaySchoolEvent(e); //Is there some way of combining these two? Need to think through use cases.
                     _db.SaveChanges();
                 });
                 return school;


### PR DESCRIPTION
This was going to be a small, granular PR, but I found another rabbit hole.
Updating SchoolModel through ReplayEvent now only gets newer events from the DB and replays them to ensure currency. It broke AddComputer, which in the process of fixing, I made a lot more changes than I intended. All working and passing tests though.